### PR TITLE
Add support for negation to f64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,12 +26,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
@@ -50,15 +56,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -69,7 +75,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -79,7 +85,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -95,17 +101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -136,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,9 +165,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.4"
+version = "4.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
+checksum = "8f644d0dac522c8b05ddc39aaaccc5b136d5dc4ff216610c5641e3be5becf56c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -175,27 +176,26 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.4"
+version = "4.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
+checksum = "af410122b9778e024f9e0fb35682cc09cc3f85cad5e8d3ba8f47a9702df6e73d"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -212,9 +212,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -290,18 +290,17 @@ checksum = "545da7d6df7f8fd0de7106669a7d0bfa3dbcfa24d81da46906ad658188b2ff7c"
 [[package]]
 name = "egglog"
 version = "0.1.0"
-source = "git+https://github.com/saulshanabrook/egg-smol?rev=4b7ec0a640b430bc86ec1d9f79e38a06e62c0cb7#4b7ec0a640b430bc86ec1d9f79e38a06e62c0cb7"
+source = "git+https://github.com/saulshanabrook/egg-smol?rev=353c4387640019bd2066991ee0488dc6d5c54168#353c4387640019bd2066991ee0488dc6d5c54168"
 dependencies = [
  "clap",
  "env_logger",
  "getrandom",
- "glob",
  "graphviz-rust",
- "hashbrown 0.13.2",
- "indexmap",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
  "instant",
  "lalrpop",
- "lalrpop-util",
+ "lalrpop-util 0.20.0",
  "lazy_static",
  "log",
  "num-integer",
@@ -321,7 +320,7 @@ name = "egglog-python"
 version = "0.4.0"
 dependencies = [
  "egglog",
- "lalrpop-util",
+ "lalrpop-util 0.19.12",
  "log",
  "ordered-float",
  "pyo3",
@@ -357,6 +356,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,7 +369,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -404,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -414,12 +419,6 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "graphviz-rust"
@@ -448,11 +447,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
  "ahash 0.8.3",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -463,18 +463,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humantime"
@@ -493,10 +484,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "1.0.7"
+name = "indexmap"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "indoc"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "instant"
@@ -526,7 +527,7 @@ dependencies = [
  "dot-structures",
  "into-attr",
  "quote",
- "syn 1.0.104",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -535,21 +536,20 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
- "windows-sys 0.48.0",
+ "hermit-abi",
+ "rustix 0.38.4",
+ "windows-sys",
 ]
 
 [[package]]
@@ -572,17 +572,17 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.8"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
 dependencies = [
  "ascii-canvas",
- "atty",
  "bit-set",
  "diff",
  "ena",
+ "is-terminal",
  "itertools",
- "lalrpop-util",
+ "lalrpop-util 0.20.0",
  "petgraph",
  "pico-args",
  "regex",
@@ -595,9 +595,18 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.8"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 dependencies = [
  "regex",
 ]
@@ -610,9 +619,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
@@ -621,10 +630,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
-name = "lock_api"
-version = "0.4.9"
+name = "linux-raw-sys"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -632,12 +647,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -704,15 +716,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "ordered-float"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a384337e997e6860ffbaa83708b2ef329fd8c54cb67a5f64d421e0f943254f"
+checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
 dependencies = [
  "num-traits",
 ]
@@ -729,22 +741,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -752,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "5f94bca7e7a599d89dea5dfa309e217e7906c3c007fb9c3299c40b10d6a315d3"
 dependencies = [
  "pest",
  "pest_generator",
@@ -762,22 +774,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "99d490fe7e8556575ff6911e45567ab95e71617f43781e5c05490dc8d75c965c"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.26",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "2674c66ebb4b4d9036012091b537aae5878970d6999f81a265034d85b136b341"
 dependencies = [
  "once_cell",
  "pest",
@@ -791,7 +803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -805,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "ppv-lite86"
@@ -823,18 +835,18 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a3d8e8a46ab2738109347433cb7b96dffda2e4a218b03ef27090238886b147"
+checksum = "e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -849,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75439f995d07ddfad42b192dfcf3bc66a7ecfd8b4a1f5f6f046aa5c2c5d7677d"
+checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -859,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839526a5c07a17ff44823679b68add4a58004de00512a95b6c1c98a6dcac0ee5"
+checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -869,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c8b57fe71fb5dcf38970ebedc2b1531cf1c14b1b9b4c560a182a57e115575c"
+checksum = "f47b0777feb17f61eea78667d61103758b243a871edc09a7786500a50467b605"
 dependencies = [
  "arc-swap",
  "log",
@@ -880,32 +892,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd44cf207476c6a9760c4653559be4f206efafb924d3e4cbf2721475fc0d6cc5"
+checksum = "a9d39c55dab3fc5a4b25bbd1ac10a2da452c4aca13bb450f22818a002e29648d"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 1.0.104",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1f43d8e30460f36350d18631ccf85ded64c059829208fe680904c65bcd0a4c"
+checksum = "97daff08a4c48320587b5224cc98d609e3c27b6d437315bd40b605c98eeb5918"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.104",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -946,7 +958,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -955,7 +967,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -971,9 +983,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -982,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -994,29 +1018,42 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.3"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.45.0",
+ "linux-raw-sys 0.3.8",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sha2"
@@ -1037,9 +1074,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "string_cache"
@@ -1076,9 +1113,9 @@ source = "git+https://github.com/oflatt/symbolic-expressions?rev=4c0ea5ca008f972
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1087,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1098,21 +1135,22 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
- "windows-sys 0.45.0",
+ "rustix 0.37.23",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1137,22 +1175,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1172,15 +1210,15 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-xid"
@@ -1190,9 +1228,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unindent"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
+checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
 name = "utf8parse"
@@ -1233,7 +1271,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.26",
  "wasm-bindgen-shared",
 ]
 
@@ -1255,7 +1293,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.26",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1299,72 +1337,27 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1374,21 +1367,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1398,21 +1379,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1422,21 +1391,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 # Use unreleased version to depend on signature improvements https://github.com/PyO3/pyo3/pull/2702
 pyo3 = { version = "0.18.1", features = ["extension-module"] }
 # egglog = { git = "https://github.com/egraphs-good/egglog", rev = "39b199d9bfce9cc47d0c54977279c5b04231e717" }
-egglog = { git = "https://github.com/saulshanabrook/egg-smol", rev = "4b7ec0a640b430bc86ec1d9f79e38a06e62c0cb7" }
+egglog = { git = "https://github.com/saulshanabrook/egg-smol", rev = "353c4387640019bd2066991ee0488dc6d5c54168" }
 
 # egglog = { path = "../egg-smol" }
 pyo3-log = "0.8.1"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,11 @@ _This project uses semantic versioning. Before 1.0.0, this means that every brea
 
 ## Unreleased
 
+## 0.6.0 (2023-07-18)
+
+- Added support for negation on `f64` sort
+- Upgraded `egg-smol` dependency ([changes](https://github.com/saulshanabrook/egg-smol/compare/4b7ec0a640b430bc86ec1d9f79e38a06e62c0cb7...353c4387640019bd2066991ee0488dc6d5c54168))
+
 ## 0.5.0 (2023-05-03)
 
 - Renamed `config()` to `run()` to better match `egglog` command

--- a/python/egglog/builtins.py
+++ b/python/egglog/builtins.py
@@ -29,69 +29,68 @@ i64Like = Union[int, "i64"]
 
 @BUILTINS.class_(egg_sort="i64")
 class i64(BaseExpr):
+    def __init__(self, value: int):
+        ...
 
-  def __init__(self, value: int):
-    ...
+    @BUILTINS.method(egg_fn="+")
+    def __add__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="+")
-  def __add__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="-")
+    def __sub__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="-")
-  def __sub__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="*")
+    def __mul__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="*")
-  def __mul__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="/")
+    def __truediv__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="/")
-  def __truediv__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="%")
+    def __mod__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="%")
-  def __mod__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="&")
+    def __and__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="&")
-  def __and__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="|")
+    def __or__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="|")
-  def __or__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="^")
+    def __xor__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="^")
-  def __xor__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="<<")
+    def __lshift__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="<<")
-  def __lshift__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn=">>")
+    def __rshift__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn=">>")
-  def __rshift__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="not-64")
+    def __invert__(self) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="not-64")
-  def __invert__(self) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="<")
+    def __lt__(self, other: i64Like) -> Unit:  # type: ignore[empty-body,has-type]
+        ...
 
-  @BUILTINS.method(egg_fn="<")
-  def __lt__(self, other: i64Like) -> Unit:  # type: ignore[empty-body,has-type]
-    ...
+    @BUILTINS.method(egg_fn=">")
+    def __gt__(self, other: i64Like) -> Unit:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn=">")
-  def __gt__(self, other: i64Like) -> Unit:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="min")
+    def min(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="min")
-  def min(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
-
-  @BUILTINS.method(egg_fn="max")
-  def max(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="max")
+    def max(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+        ...
 
 
 f64Like = Union[float, "f64"]
@@ -99,57 +98,56 @@ f64Like = Union[float, "f64"]
 
 @BUILTINS.class_(egg_sort="f64")
 class f64(BaseExpr):
+    def __init__(self, value: float):
+        ...
 
-  def __init__(self, value: float):
-    ...
+    @BUILTINS.method(egg_fn="neg")
+    def __neg__(self) -> f64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="neg")
-  def __neg__(self) -> f64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="+")
+    def __add__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="+")
-  def __add__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="-")
+    def __sub__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="-")
-  def __sub__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="*")
+    def __mul__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="*")
-  def __mul__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="/")
+    def __truediv__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="/")
-  def __truediv__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="%")
+    def __mod__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="%")
-  def __mod__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="<")
+    def __lt__(self, other: f64Like) -> Unit:  # type: ignore[empty-body,has-type]
+        ...
 
-  @BUILTINS.method(egg_fn="<")
-  def __lt__(self, other: f64Like) -> Unit:  # type: ignore[empty-body,has-type]
-    ...
+    @BUILTINS.method(egg_fn=">")
+    def __gt__(self, other: f64Like) -> Unit:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn=">")
-  def __gt__(self, other: f64Like) -> Unit:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="<=")
+    def __le__(self, other: f64Like) -> Unit:  # type: ignore[empty-body,has-type]
+        ...
 
-  @BUILTINS.method(egg_fn="<=")
-  def __le__(self, other: f64Like) -> Unit:  # type: ignore[empty-body,has-type]
-    ...
+    @BUILTINS.method(egg_fn=">=")
+    def __ge__(self, other: f64Like) -> Unit:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn=">=")
-  def __ge__(self, other: f64Like) -> Unit:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="min")
+    def min(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="min")
-  def min(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-    ...
-
-  @BUILTINS.method(egg_fn="max")
-  def max(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="max")
+    def max(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+        ...
 
 
 StringLike = Union[str, "String"]
@@ -157,14 +155,13 @@ StringLike = Union[str, "String"]
 
 @BUILTINS.class_
 class String(BaseExpr):
-
-  def __init__(self, value: str):
-    ...
+    def __init__(self, value: str):
+        ...
 
 
 @BUILTINS.function(egg_fn="+")
 def join(*strings: StringLike) -> String:  # type: ignore[empty-body]
-  ...
+    ...
 
 
 T = TypeVar("T", bound=BaseExpr)
@@ -173,182 +170,178 @@ V = TypeVar("V", bound=BaseExpr)
 
 @BUILTINS.class_(egg_sort="Map")
 class Map(BaseExpr, Generic[T, V]):
+    @BUILTINS.method(egg_fn="map-empty")
+    @classmethod
+    def empty(cls) -> Map[T, V]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="map-empty")
-  @classmethod
-  def empty(cls) -> Map[T, V]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="map-insert")
+    def insert(self, key: T, value: V) -> Map[T, V]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="map-insert")
-  def insert(self, key: T, value: V) -> Map[T, V]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="map-get")
+    def __getitem__(self, key: T) -> V:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="map-get")
-  def __getitem__(self, key: T) -> V:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="map-not-contains")
+    def not_contains(self, key: T) -> Unit:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="map-not-contains")
-  def not_contains(self, key: T) -> Unit:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="map-contains")
+    def contains(self, key: T) -> Unit:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="map-contains")
-  def contains(self, key: T) -> Unit:  # type: ignore[empty-body]
-    ...
-
-  @BUILTINS.method(egg_fn="map-remove")
-  def remove(self, key: T) -> Map[T, V]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="map-remove")
+    def remove(self, key: T) -> Map[T, V]:  # type: ignore[empty-body]
+        ...
 
 
 @BUILTINS.class_(egg_sort="Set")
 class Set(BaseExpr, Generic[T]):
+    @BUILTINS.method(egg_fn="set-of")
+    def __init__(self, *args: T) -> None:
+        ...
 
-  @BUILTINS.method(egg_fn="set-of")
-  def __init__(self, *args: T) -> None:
-    ...
+    @BUILTINS.method(egg_fn="set-empty")
+    @classmethod
+    def empty(cls) -> Set[T]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="set-empty")
-  @classmethod
-  def empty(cls) -> Set[T]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="set-insert")
+    def insert(self, value: T) -> Set[T]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="set-insert")
-  def insert(self, value: T) -> Set[T]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="set-not-contains")
+    def not_contains(self, value: T) -> Unit:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="set-not-contains")
-  def not_contains(self, value: T) -> Unit:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="set-contains")
+    def contains(self, value: T) -> Unit:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="set-contains")
-  def contains(self, value: T) -> Unit:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="set-remove")
+    def remove(self, value: T) -> Set[T]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="set-remove")
-  def remove(self, value: T) -> Set[T]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="set-union")
+    def __or__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="set-union")
-  def __or__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="set-diff")
+    def __sub__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="set-diff")
-  def __sub__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
-    ...
-
-  @BUILTINS.method(egg_fn="set-intersect")
-  def __and__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="set-intersect")
+    def __and__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
+        ...
 
 
 @BUILTINS.class_(egg_sort="Rational")
 class Rational(BaseExpr):
+    @BUILTINS.method(egg_fn="rational")
+    def __init__(self, num: i64Like, den: i64Like):
+        ...
 
-  @BUILTINS.method(egg_fn="rational")
-  def __init__(self, num: i64Like, den: i64Like):
-    ...
+    @BUILTINS.method(egg_fn="to-f64")
+    def to_f64(self) -> f64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="to-f64")
-  def to_f64(self) -> f64:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="+")
+    def __add__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="+")
-  def __add__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="-")
+    def __sub__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="-")
-  def __sub__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="*")
+    def __mul__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="*")
-  def __mul__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="/")
+    def __truediv__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="/")
-  def __truediv__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="min")
+    def min(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="min")
-  def min(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="max")
+    def max(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="max")
-  def max(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="neg")
+    def __neg__(self) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="neg")
-  def __neg__(self) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="abs")
+    def __abs__(self) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="abs")
-  def __abs__(self) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="floor")
+    def floor(self) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="floor")
-  def floor(self) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="ceil")
+    def ceil(self) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="ceil")
-  def ceil(self) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="round")
+    def round(self) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="round")
-  def round(self) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="pow")
+    def __pow__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="pow")
-  def __pow__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="log")
+    def log(self) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="log")
-  def log(self) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="sqrt")
+    def sqrt(self) -> Rational:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="sqrt")
-  def sqrt(self) -> Rational:  # type: ignore[empty-body]
-    ...
-
-  @BUILTINS.method(egg_fn="cbrt")
-  def cbrt(self) -> Rational:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="cbrt")
+    def cbrt(self) -> Rational:  # type: ignore[empty-body]
+        ...
 
 
 @BUILTINS.class_(egg_sort="Vec")
 class Vec(BaseExpr, Generic[T]):
+    @BUILTINS.method(egg_fn="vec-of")
+    def __init__(self, *args: T) -> None:
+        ...
 
-  @BUILTINS.method(egg_fn="vec-of")
-  def __init__(self, *args: T) -> None:
-    ...
+    @BUILTINS.method(egg_fn="vec-empty")
+    @classmethod
+    def empty(cls) -> Vec[T]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="vec-empty")
-  @classmethod
-  def empty(cls) -> Vec[T]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="vec-append")
+    def append(self, *others: Vec[T]) -> Vec[T]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="vec-append")
-  def append(self, *others: Vec[T]) -> Vec[T]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="vec-push")
+    def push(self, value: T) -> Vec[T]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="vec-push")
-  def push(self, value: T) -> Vec[T]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="vec-pop")
+    def pop(self) -> Vec[T]:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="vec-pop")
-  def pop(self) -> Vec[T]:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="vec-not-contains")
+    def not_contains(self, value: T) -> Unit:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="vec-not-contains")
-  def not_contains(self, value: T) -> Unit:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="vec-contains")
+    def contains(self, value: T) -> Unit:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="vec-contains")
-  def contains(self, value: T) -> Unit:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="vec-length")
+    def length(self) -> i64:  # type: ignore[empty-body]
+        ...
 
-  @BUILTINS.method(egg_fn="vec-length")
-  def length(self) -> i64:  # type: ignore[empty-body]
-    ...
-
-  @BUILTINS.method(egg_fn="vec-get")
-  def __getitem__(self, index: i64Like) -> T:  # type: ignore[empty-body]
-    ...
+    @BUILTINS.method(egg_fn="vec-get")
+    def __getitem__(self, index: i64Like) -> T:  # type: ignore[empty-body]
+        ...

--- a/python/egglog/builtins.py
+++ b/python/egglog/builtins.py
@@ -2,7 +2,6 @@
 Builtin sorts and function to egg.
 """
 
-
 from __future__ import annotations
 
 from typing import Generic, TypeVar, Union
@@ -24,75 +23,75 @@ __all__ = [
     "join",
 ]
 
-
 # The types which can be converted into an i64
 i64Like = Union[int, "i64"]
 
 
 @BUILTINS.class_(egg_sort="i64")
 class i64(BaseExpr):
-    def __init__(self, value: int):
-        ...
 
-    @BUILTINS.method(egg_fn="+")
-    def __add__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  def __init__(self, value: int):
+    ...
 
-    @BUILTINS.method(egg_fn="-")
-    def __sub__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="+")
+  def __add__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="*")
-    def __mul__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="-")
+  def __sub__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="/")
-    def __truediv__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="*")
+  def __mul__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="%")
-    def __mod__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="/")
+  def __truediv__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="&")
-    def __and__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="%")
+  def __mod__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="|")
-    def __or__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="&")
+  def __and__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="^")
-    def __xor__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="|")
+  def __or__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="<<")
-    def __lshift__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="^")
+  def __xor__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn=">>")
-    def __rshift__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="<<")
+  def __lshift__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="not-64")
-    def __invert__(self) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn=">>")
+  def __rshift__(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="<")
-    def __lt__(self, other: i64Like) -> Unit:  # type: ignore[empty-body,has-type]
-        ...
+  @BUILTINS.method(egg_fn="not-64")
+  def __invert__(self) -> i64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn=">")
-    def __gt__(self, other: i64Like) -> Unit:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="<")
+  def __lt__(self, other: i64Like) -> Unit:  # type: ignore[empty-body,has-type]
+    ...
 
-    @BUILTINS.method(egg_fn="min")
-    def min(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn=">")
+  def __gt__(self, other: i64Like) -> Unit:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="max")
-    def max(self, other: i64Like) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="min")
+  def min(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
+
+  @BUILTINS.method(egg_fn="max")
+  def max(self, other: i64Like) -> i64:  # type: ignore[empty-body]
+    ...
 
 
 f64Like = Union[float, "f64"]
@@ -100,52 +99,57 @@ f64Like = Union[float, "f64"]
 
 @BUILTINS.class_(egg_sort="f64")
 class f64(BaseExpr):
-    def __init__(self, value: float):
-        ...
 
-    @BUILTINS.method(egg_fn="+")
-    def __add__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-        ...
+  def __init__(self, value: float):
+    ...
 
-    @BUILTINS.method(egg_fn="-")
-    def __sub__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="neg")
+  def __neg__(self) -> f64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="*")
-    def __mul__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="+")
+  def __add__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="/")
-    def __truediv__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="-")
+  def __sub__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="%")
-    def __mod__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="*")
+  def __mul__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="<")
-    def __lt__(self, other: f64Like) -> Unit:  # type: ignore[empty-body,has-type]
-        ...
+  @BUILTINS.method(egg_fn="/")
+  def __truediv__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn=">")
-    def __gt__(self, other: f64Like) -> Unit:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="%")
+  def __mod__(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="<=")
-    def __le__(self, other: f64Like) -> Unit:  # type: ignore[empty-body,has-type]
-        ...
+  @BUILTINS.method(egg_fn="<")
+  def __lt__(self, other: f64Like) -> Unit:  # type: ignore[empty-body,has-type]
+    ...
 
-    @BUILTINS.method(egg_fn=">=")
-    def __ge__(self, other: f64Like) -> Unit:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn=">")
+  def __gt__(self, other: f64Like) -> Unit:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="min")
-    def min(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="<=")
+  def __le__(self, other: f64Like) -> Unit:  # type: ignore[empty-body,has-type]
+    ...
 
-    @BUILTINS.method(egg_fn="max")
-    def max(self, other: f64Like) -> f64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn=">=")
+  def __ge__(self, other: f64Like) -> Unit:  # type: ignore[empty-body]
+    ...
+
+  @BUILTINS.method(egg_fn="min")
+  def min(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+    ...
+
+  @BUILTINS.method(egg_fn="max")
+  def max(self, other: f64Like) -> f64:  # type: ignore[empty-body]
+    ...
 
 
 StringLike = Union[str, "String"]
@@ -153,13 +157,14 @@ StringLike = Union[str, "String"]
 
 @BUILTINS.class_
 class String(BaseExpr):
-    def __init__(self, value: str):
-        ...
+
+  def __init__(self, value: str):
+    ...
 
 
 @BUILTINS.function(egg_fn="+")
 def join(*strings: StringLike) -> String:  # type: ignore[empty-body]
-    ...
+  ...
 
 
 T = TypeVar("T", bound=BaseExpr)
@@ -168,178 +173,182 @@ V = TypeVar("V", bound=BaseExpr)
 
 @BUILTINS.class_(egg_sort="Map")
 class Map(BaseExpr, Generic[T, V]):
-    @BUILTINS.method(egg_fn="map-empty")
-    @classmethod
-    def empty(cls) -> Map[T, V]:  # type: ignore[empty-body]
-        ...
 
-    @BUILTINS.method(egg_fn="map-insert")
-    def insert(self, key: T, value: V) -> Map[T, V]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="map-empty")
+  @classmethod
+  def empty(cls) -> Map[T, V]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="map-get")
-    def __getitem__(self, key: T) -> V:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="map-insert")
+  def insert(self, key: T, value: V) -> Map[T, V]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="map-not-contains")
-    def not_contains(self, key: T) -> Unit:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="map-get")
+  def __getitem__(self, key: T) -> V:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="map-contains")
-    def contains(self, key: T) -> Unit:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="map-not-contains")
+  def not_contains(self, key: T) -> Unit:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="map-remove")
-    def remove(self, key: T) -> Map[T, V]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="map-contains")
+  def contains(self, key: T) -> Unit:  # type: ignore[empty-body]
+    ...
+
+  @BUILTINS.method(egg_fn="map-remove")
+  def remove(self, key: T) -> Map[T, V]:  # type: ignore[empty-body]
+    ...
 
 
 @BUILTINS.class_(egg_sort="Set")
 class Set(BaseExpr, Generic[T]):
-    @BUILTINS.method(egg_fn="set-of")
-    def __init__(self, *args: T) -> None:
-        ...
 
-    @BUILTINS.method(egg_fn="set-empty")
-    @classmethod
-    def empty(cls) -> Set[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="set-of")
+  def __init__(self, *args: T) -> None:
+    ...
 
-    @BUILTINS.method(egg_fn="set-insert")
-    def insert(self, value: T) -> Set[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="set-empty")
+  @classmethod
+  def empty(cls) -> Set[T]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="set-not-contains")
-    def not_contains(self, value: T) -> Unit:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="set-insert")
+  def insert(self, value: T) -> Set[T]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="set-contains")
-    def contains(self, value: T) -> Unit:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="set-not-contains")
+  def not_contains(self, value: T) -> Unit:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="set-remove")
-    def remove(self, value: T) -> Set[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="set-contains")
+  def contains(self, value: T) -> Unit:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="set-union")
-    def __or__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="set-remove")
+  def remove(self, value: T) -> Set[T]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="set-diff")
-    def __sub__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="set-union")
+  def __or__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="set-intersect")
-    def __and__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="set-diff")
+  def __sub__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
+    ...
+
+  @BUILTINS.method(egg_fn="set-intersect")
+  def __and__(self, other: Set[T]) -> Set[T]:  # type: ignore[empty-body]
+    ...
 
 
 @BUILTINS.class_(egg_sort="Rational")
 class Rational(BaseExpr):
-    @BUILTINS.method(egg_fn="rational")
-    def __init__(self, num: i64Like, den: i64Like):
-        ...
 
-    @BUILTINS.method(egg_fn="to-f64")
-    def to_f64(self) -> f64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="rational")
+  def __init__(self, num: i64Like, den: i64Like):
+    ...
 
-    @BUILTINS.method(egg_fn="+")
-    def __add__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="to-f64")
+  def to_f64(self) -> f64:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="-")
-    def __sub__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="+")
+  def __add__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="*")
-    def __mul__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="-")
+  def __sub__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="/")
-    def __truediv__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="*")
+  def __mul__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="min")
-    def min(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="/")
+  def __truediv__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="max")
-    def max(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="min")
+  def min(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="neg")
-    def __neg__(self) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="max")
+  def max(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="abs")
-    def __abs__(self) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="neg")
+  def __neg__(self) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="floor")
-    def floor(self) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="abs")
+  def __abs__(self) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="ceil")
-    def ceil(self) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="floor")
+  def floor(self) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="round")
-    def round(self) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="ceil")
+  def ceil(self) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="pow")
-    def __pow__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="round")
+  def round(self) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="log")
-    def log(self) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="pow")
+  def __pow__(self, other: Rational) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="sqrt")
-    def sqrt(self) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="log")
+  def log(self) -> Rational:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="cbrt")
-    def cbrt(self) -> Rational:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="sqrt")
+  def sqrt(self) -> Rational:  # type: ignore[empty-body]
+    ...
+
+  @BUILTINS.method(egg_fn="cbrt")
+  def cbrt(self) -> Rational:  # type: ignore[empty-body]
+    ...
 
 
 @BUILTINS.class_(egg_sort="Vec")
 class Vec(BaseExpr, Generic[T]):
-    @BUILTINS.method(egg_fn="vec-of")
-    def __init__(self, *args: T) -> None:
-        ...
 
-    @BUILTINS.method(egg_fn="vec-empty")
-    @classmethod
-    def empty(cls) -> Vec[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="vec-of")
+  def __init__(self, *args: T) -> None:
+    ...
 
-    @BUILTINS.method(egg_fn="vec-append")
-    def append(self, *others: Vec[T]) -> Vec[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="vec-empty")
+  @classmethod
+  def empty(cls) -> Vec[T]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="vec-push")
-    def push(self, value: T) -> Vec[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="vec-append")
+  def append(self, *others: Vec[T]) -> Vec[T]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="vec-pop")
-    def pop(self) -> Vec[T]:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="vec-push")
+  def push(self, value: T) -> Vec[T]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="vec-not-contains")
-    def not_contains(self, value: T) -> Unit:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="vec-pop")
+  def pop(self) -> Vec[T]:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="vec-contains")
-    def contains(self, value: T) -> Unit:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="vec-not-contains")
+  def not_contains(self, value: T) -> Unit:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="vec-length")
-    def length(self) -> i64:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="vec-contains")
+  def contains(self, value: T) -> Unit:  # type: ignore[empty-body]
+    ...
 
-    @BUILTINS.method(egg_fn="vec-get")
-    def __getitem__(self, index: i64Like) -> T:  # type: ignore[empty-body]
-        ...
+  @BUILTINS.method(egg_fn="vec-length")
+  def length(self) -> i64:  # type: ignore[empty-body]
+    ...
+
+  @BUILTINS.method(egg_fn="vec-get")
+  def __getitem__(self, index: i64Like) -> T:  # type: ignore[empty-body]
+    ...

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -233,12 +233,5 @@ def test_f64_negation() -> None:
 
     # expr3 = -(-2.0)
     expr3 = egraph.define("expr3", -(-f64(2.0)))
-
-    x, y = vars_("x y", f64)
-
-    egraph.register(rewrite(-(-x)).to(x))
-
-    egraph.run(10)
-
     egraph.check(eq(expr1).to(-expr2))
     egraph.check(eq(expr3).to(expr2))

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -221,3 +221,24 @@ def test_modules() -> None:
 
     egraph.register(rewrite(OtherNumeric(1)).to(from_numeric(Numeric.ONE)))
     assert expr_parts(egraph.simplify(OtherNumeric(i64(1)), 10)) == expr_parts(from_numeric(Numeric.ONE))
+
+
+def test_f64_negation() -> None:
+    egraph = EGraph()
+    # expr1 = -2.0
+    expr1 = egraph.define("expr1", -f64(2.0))
+
+    # expr2 = 2.0
+    expr2 = egraph.define("expr2", f64(2.0))
+
+    # expr3 = -(-2.0)
+    expr3 = egraph.define("expr3", -(-f64(2.0)))
+
+    x, y = vars_("x y", f64)
+
+    egraph.register(rewrite(-(-x)).to(x))
+
+    egraph.run(10)
+
+    egraph.check(eq(expr1).to(-expr2))
+    egraph.check(eq(expr3).to(expr2))


### PR DESCRIPTION
Now that upstream `egglog` supports `neg` for `f64` (https://github.com/egraphs-good/egglog/pull/168), this PR adds support to the `f64` sort in these bindings.

Closes #32 