### PR TITLE
Fix exposing birewrite

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@ _This project uses semantic versioning_
 
 ## Unreleased
 
+- Fixes not exposing `birewrite` at top level (#72)[https://github.com/metadsl/egglog-python/pull/72].
+
 ## 1.0.1 (2023-10-26)
 
 - Adds youtube video to [presentation slides](./explanation/2023_07_presentation).

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -53,6 +53,7 @@ __all__ = [
     "Expr",
     "Unit",
     "rewrite",
+    "birewrite",
     "eq",
     "panic",
     "let",


### PR DESCRIPTION
The `birewrite` command wasn't exposed by accident, so couldn't be imported from the `egglog` module.

Thanks [Erick Ochoa for reporting](https://egraphs.zulipchat.com/#narrow/stream/375765-egglog/topic/Python.20bindings/near/401628934).