### PR TITLE
Update visualization names

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 _This project uses semantic versioning_
 
+## 3.1.0 (UNRELEASED)
+
+- Update graphs to include more compact Python names of functions (#79)[https://github.com/metadsl/egglog-python/pull/79].
+
 ## 3.0.0 (2023-11-19)
 
 Add support for outputing the serialization e-graph from the low level bindings. Note that this is not yet exposed a the high level yet.

--- a/python/egglog/egraph.py
+++ b/python/egglog/egraph.py
@@ -803,6 +803,7 @@ class EGraph(_BaseModule):
         kwargs.setdefault("split_primitive_outputs", True)
         n_inline = kwargs.pop("n_inline_leaves", 0)
         serialized = self._egraph.serialize(**kwargs)  # type: ignore[misc]
+        serialized.map_ops(self._mod_decls.op_mapping())
         for _ in range(n_inline):
             serialized.inline_leaves()
         original = serialized.to_dot()


### PR DESCRIPTION
This PR builds on #78 to make the names in the visualizations shorter, by using the Python names instead of the egglog names. Also for methods that are operators, it uses the inline operator, i.e. `+` instead of the method name `__add__`.


Before:

![old](https://github.com/metadsl/egglog-python/assets/1186124/6df44e90-1d01-4dbf-8206-0ba22f16170a)


After:
![new](https://github.com/metadsl/egglog-python/assets/1186124/c14a5267-2b42-4d53-b853-89d65a03a7c2)

