### PR TITLE
Add way to convert egraph to egglog string

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ _This project uses semantic versioning_
 ## 3.1.0 (UNRELEASED)
 
 - Update graphs to include more compact Python names of functions (#79)[https://github.com/metadsl/egglog-python/pull/79].
+- Add way method to get egglog source from e-graph.
 
 ## 3.0.0 (2023-11-19)
 

--- a/docs/reference/egglog-translation.md
+++ b/docs/reference/egglog-translation.md
@@ -6,6 +6,8 @@ file_format: mystnb
 
 The high level bindings available at the top module (`egglog`) expose most of the functionality of the `egglog` text format. This guide exaplin how to translate between the two.
 
+Any EGraph can also be converted to egglog with the `egraph.as_egglog_string` property, as long as it was created with `Egraph(save_egglog_string=True)`.
+
 ## Unsupported features
 
 The currently unsupported features are:

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib
+from multiprocessing import Value
 import pathlib
 from copy import copy
 from typing import ClassVar, Union
@@ -517,3 +518,15 @@ def test_eval():
     assert egraph.eval(f64(10.0)) == 10.0
     assert egraph.eval(Bool(True)) is True
     assert egraph.eval(PyObject((1, 2))) == (1, 2)
+
+
+def test_egglog_string():
+    egraph = EGraph(save_egglog_string=True)
+    egraph.register((i64(1)))
+    assert egraph.as_egglog_string
+
+def test_no_egglog_string():
+    egraph = EGraph()
+    egraph.register((i64(1)))
+    with pytest.raises(ValueError):
+        egraph.as_egglog_string


### PR DESCRIPTION
Adds a way to convert a running e-graph to an egglog source. Closes #82.