### PR TITLE
Add support for upcasting when passing args to rewrite, eq, etc

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,8 +5,9 @@ _This project uses semantic versioning_
 ## 3.1.0 (UNRELEASED)
 
 - Update graphs to include more compact Python names of functions (#79)[https://github.com/metadsl/egglog-python/pull/79].
-- Add method to get egglog source from e-graph.
-- Add `include_cost` flag to `egraph.extract` to return the integer cost as well as an expression.
+- Add method to get egglog source from e-graph (#82)[https://github.com/metadsl/egglog-python/pull/82].
+- Add `include_cost` flag to `egraph.extract` to return the integer cost as well as an expression (#86)[https://github.com/metadsl/egglog-python/pull/86].
+- Automatically try converting arguments to `eq`, `rewrite`, `set_`, and `union` to the correct type (#84)[https://github.com/metadsl/egglog-python/pull/84].
 
 ## 3.0.0 (2023-11-19)
 

--- a/python/egglog/runtime.py
+++ b/python/egglog/runtime.py
@@ -119,6 +119,14 @@ def convert(source: object, target: type[V]) -> V:
     return cast(V, _resolve_literal(target_ref.to_var(), source))
 
 
+def convert_to_same_type(source: object, target: RuntimeExpr) -> RuntimeExpr:
+    """
+    Convert a source object to the same type as the target.
+    """
+    tp = target.__egg_typed_expr__.tp
+    return _resolve_literal(tp.to_var(), source)
+
+
 def process_tp(tp: type | RuntimeTypeArgType) -> JustTypeRef | type:
     if isinstance(tp, RuntimeClass | RuntimeParamaterizedClass):
         return class_to_ref(tp)

--- a/python/tests/test_high_level.py
+++ b/python/tests/test_high_level.py
@@ -473,6 +473,9 @@ def test_upcast_args():
     res: Expr = Int(10) + -0.1  # type: ignore
     assert expr_parts(res) == expr_parts(Float.from_int(Int(10)) + Float(-0.1))
 
+def test_rewrite_upcasts():
+    rewrite(i64(1)).to(0) # type: ignore
+
 
 def test_upcast_self_lower_cost():
     # Verifies that self will be upcasted, if that upcast has a lower cast than converting the other arg


### PR DESCRIPTION
Closes #84 by upcasting subsequent passed rewrite, eq, etc to the type of the first arg.